### PR TITLE
Fix for payment assignment on Trustly orders

### DIFF
--- a/spec/models/adyen_notification_spec.rb
+++ b/spec/models/adyen_notification_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe AdyenNotification do
       let(:attr) { :psp_reference }
       include_examples "finds the payment"
     end
+
+    context "payment with no reference" do
+      let!(:payment) { create :payment, response_code: nil }
+
+      context "normal notification" do
+        let!(:notification) {
+          described_class.new :merchant_reference => payment.order.number
+        }
+        include_examples "finds the payment"
+      end
+    end
   end
 
   describe "#build" do


### PR DESCRIPTION
Trustly creates duplicate payment objects because the redirect back doesn't have the required reference to match up with the Adyen notification. This fixes it by taking the last payment on an order if the reference we usually expect isn't around.

Dylan from Stembolt isn't convinced of this as a possible solution, but in absence of a better one I think we should try this out for now.
