### PR TITLE
Revert back to relying on ActiveRecord for race condition

### DIFF
--- a/spec/lib/spree/adyen/invoice_spec.rb
+++ b/spec/lib/spree/adyen/invoice_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Adyen::Invoice do
     let(:tax_rate_country) { address.country }
     let(:tax_category) { create(:tax_category) }
     let!(:zone) { create(:zone, name: "Country Zone", default_tax: true, countries: [tax_rate_country]) }
-    let!(:rate) { create(:tax_rate, tax_category: tax_category, amount: 0.19, included_in_price: true, zone: zone) }
+    let!(:rate) { create(:tax_rate, tax_categories: [tax_category], amount: 0.19, included_in_price: true, zone: zone) }
     let(:order) do
       create(
         :order_with_line_items,


### PR DESCRIPTION
executing `notification_exists?(params)` doesn't guarantee mutual exclusion.

Our threads a, b have the following format:
```
1) if notification_exists?(params) -> exit
2) notification = AdyenNotification.build(params)
3) notification.save!
```

If thread a executes line 1 it will move to line 2 as no notification exists right now. After that thread b executes line 1, it will also move to line 2 as no notification exists right now. Therefore, we now have two threads in an unsafe state.

Relying on indexes for uniqueness is not nice. I believe we can also use `find_or_create_by`, or use `save` without bang and to check for errors (not nicer)
