### PR TITLE
Pass `resURL` to Adyen so we can return to whatever host sent the request

### DIFF
--- a/app/controllers/spree/adyen/hpps_controller.rb
+++ b/app/controllers/spree/adyen/hpps_controller.rb
@@ -12,7 +12,9 @@ module Spree
       def directory
         @brands = Spree::Adyen::HPP.payment_methods_from_directory(
           @order,
-          @payment_method)
+          @payment_method,
+          result_url: spree.adyen_confirmation_url,
+        )
 
         respond_to do |format|
           format.html

--- a/spec/controllers/spree/adyen/hpps_controller_spec.rb
+++ b/spec/controllers/spree/adyen/hpps_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Spree::Adyen::HppsController, type: :controller do
 
     before do
       allow(Spree::Adyen::HPP).to receive(:payment_methods_from_directory).
-        with(order, payment_method).
+        with(order, payment_method, result_url: 'http://test.host/checkout/payment/adyen').
         and_return(parsed_directory_response)
     end
 

--- a/spec/lib/spree/adyen/hpp_spec.rb
+++ b/spec/lib/spree/adyen/hpp_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Spree::Adyen::HPP do
 
     it "calls form_payment_methods_and_urls with adyen response" do
       expect(described_class).to receive(:form_payment_methods_and_urls).
-        with({ "test" => "response" }, order, payment_method)
+        with({ "test" => "response" }, order, payment_method, result_url: nil)
       subject
     end
   end
@@ -291,7 +291,7 @@ RSpec.describe Spree::Adyen::HPP do
 
     it "calls endpoint url with the expected params" do
       expect(described_class).to receive(:endpoint_url).
-        with("details", order, payment_method, { brandCode: "paypal" })
+        with("details", order, payment_method, { brandCode: "paypal", resURL: nil })
       subject
     end
   end


### PR DESCRIPTION
Previously you had to configure a single return url in the Adyen admin. That is
a problem for the rebrand and for non-production usage (since we have many
domains that use the same adyen sandbox account).

This doesn't solve the same sort of problem for server-to-server requests, but
those shouldn't be a problem for the rebrand at least since they don't need to
be on the same domain that the user was on.

FYI I ran the specs locally and they are green.